### PR TITLE
data.table Depends->Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 /rsc/
 /wfx/
 /zfx/
+
+#artifacts of R CMD build/check
+*.Rcheck
+*.tar.gz
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,10 +20,11 @@ Description: Basic infrastructure and several algorithms for 1d-4d bin packing
     The item can be rotated into any orthogonal direction, and no further
     restrictions implied.
 License: MIT + file LICENSE
-Depends: R (>= 3.0.0),
-    magrittr, data.table
+Depends: R (>= 3.0.2),
+    magrittr
 Imports: methods,
-    Rcpp (>= 0.12.7)
+    Rcpp (>= 0.12.7),
+    data.table
 Suggests: testthat,
     knitr, rmarkdown, rgl
 LinkingTo: Rcpp, RcppArmadillo (>= 0.7.400.2.0)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,5 @@
 useDynLib(gbp)
+importFrom(data.table, data.table, copy)
 importFrom(Rcpp, evalCpp)
-import(methods, magrittr, data.table, Rcpp)
+import(methods, magrittr, Rcpp)
 exportPattern("^[[:alpha:]]+")

--- a/R/bpp_viewer.r
+++ b/R/bpp_viewer.r
@@ -165,6 +165,9 @@ bpp_viewer <- function(
 #' @family bpp_viewer
 #' @rdname bpp_viewer_single
 #' @export
+.N = NULL
+`:=` = function(...) NULL
+
 bpp_viewer_single <- function(
   it, bn, title = NULL, subtitle = NULL, it_rgl_control = NULL, bn_rgl_control = NULL, label_it = TRUE, label_bn = TRUE
 ) {
@@ -337,4 +340,3 @@ create_bn_rgl_control <- function() {
 
 }
 #------------------------------------------------------------------------------#
-


### PR DESCRIPTION
Thanks for using `data.table`! We noticed you are `Depend`ing on us and recently decided to strongly discourage downstream packages from doing so -- we think `Imports` is always better.

This PR attempts to make the migration from Depends to Imports for `data.table`.

If you have a strong reason for preferring `Depends`, we'd love to hear it over at our issue tracker:

https://github.com/Rdatatable/data.table/issues/3076